### PR TITLE
using post-update-cmd composer command event

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ composer install
 
 ## Usage
 
-Copy the contents of `config_sample.php` to `config.php` and adjust the values accordingly:
+Edit the contents of `config.php` and adjust the values accordingly:
 
 ```
 return $dolphin_config = [

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,11 @@
         "psr-4": {
             "Dolphin\\": "src/"
         }
-    }
+    },
+
+    "scripts": {
+        "post-update-cmd": [
+            "@php -r \"file_exists('config.php') || copy('config_sample.php', 'config.php');\""
+        ]
+    }    
 }


### PR DESCRIPTION
I am using post-update-cmd composer command event to copy the config sample file; this way, there is no need to create the config file manually.

More info about the `post-update-cmd` command:

**post-update-cmd**: occurs after the update command has been executed, or after the install command has been executed without a lock file present.
